### PR TITLE
Feature: Add REGEX path ignores

### DIFF
--- a/src/components/findings-context.tsx
+++ b/src/components/findings-context.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import browser from "webextension-polyfill";
-import { Finding, Search } from "../shared/types";
+import { Finding, Search, Settings } from "../shared/types";
+import { defaultSettings } from "../shared/constants";
 
 interface FindingsContextType {
   findings: Finding[];
@@ -30,6 +31,24 @@ export const FindingsProvider = ({
     source: "",
     target: "",
   });
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+
+  useEffect(() => {
+    browser.storage.local.get("settings").then((items) => {
+      if (items.settings) setSettings(items.settings);
+    });
+    const listener = (
+      changes: browser.Storage.StorageAreaOnChangedChangesType,
+    ) => {
+      if (changes.settings) {
+        setSettings(changes.settings.newValue);
+      }
+    };
+    browser.storage.local.onChanged.addListener(listener);
+    return () => {
+      browser.storage.local.onChanged.removeListener(listener);
+    };
+  }, []);
 
   const fetchFindings = () => {
     browser.storage.local.get("findings").then((data) => {
@@ -60,6 +79,10 @@ export const FindingsProvider = ({
   }, []);
 
   useEffect(() => {
+    const activePatterns = (settings.filters?.ignorePatterns ?? [])
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+
     let valueSearch = search.value.toLowerCase().trim();
     let targetSearch = search.target.toLowerCase().trim();
     let sourceSearch = search.source.toLowerCase().trim();
@@ -78,12 +101,31 @@ export const FindingsProvider = ({
 
     let filtered = rawFindings;
 
+    if (activePatterns.length > 0) {
+      filtered = filtered.filter((f) => {
+        const targetPath = (() => {
+          try {
+            return new URL(f.target.url).pathname;
+          } catch {
+            return f.target.url;
+          }
+        })();
+        return !activePatterns.some((pattern) => {
+          try {
+            return new RegExp(pattern).test(targetPath);
+          } catch {
+            return false;
+          }
+        });
+      });
+    }
+
     if (
       valueTerms.length > 0 ||
       targetTerms.length > 0 ||
       sourceTerms.length > 0
     ) {
-      filtered = rawFindings.filter((f) => {
+      filtered = filtered.filter((f) => {
         const source = f.source.url.toLowerCase();
         const target = f.target.url.toLowerCase();
         const value = f.source.value.toLowerCase();
@@ -100,7 +142,7 @@ export const FindingsProvider = ({
     }
 
     setFilteredFindings(filtered);
-  }, [search, rawFindings]);
+  }, [search, rawFindings, settings]);
 
   return (
     <FindingsContext.Provider

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -132,6 +132,30 @@ export default function Popup() {
         />
       </div>
       <hr className="my-4" />
+      <div>
+        <label className="block text-sm font-medium text-gray-900 mb-1">
+          Ignore Patterns
+        </label>
+        <p className="text-xs text-gray-500 mb-2">
+          One regex per line. Findings whose target path matches any pattern
+          will be hidden.
+        </p>
+        <textarea
+          className="w-full p-2 text-sm font-mono border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-gray-200 resize-y"
+          rows={4}
+          placeholder={"/stealth\n/health-check"}
+          value={settings.filters.ignorePatterns.join("\n")}
+          onChange={(e) => {
+            setSettings({
+              ...settings,
+              filters: {
+                ignorePatterns: e.target.value.split("\n"),
+              },
+            });
+          }}
+        />
+      </div>
+      <hr className="my-4" />
       <InfoAlert message="Open the DevTools Gecko panel to see the findings." />
     </div>
   );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,9 @@ const defaultSettings: Settings = {
   display: {
     clearOnRefresh: false,
   },
+  filters: {
+    ignorePatterns: [],
+  },
 };
 
 export { defaultSettings };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,6 +46,9 @@ interface Settings {
   display: {
     clearOnRefresh: boolean;
   };
+  filters: {
+    ignorePatterns: string[];
+  };
 }
 
 interface Search {


### PR DESCRIPTION
Introduces a Path Exclusion Filter feature to reduce noise during discovery. Users can now define a list of Regex patterns to ignore specific targets, such as tracking scripts, third-party libraries, or known noisy endpoints.

- **Regex-based Filtering**: Added a settings configuration to input exclusion patterns.
- **Target Validation**: Updated the discovery logic to skip paths matching any active exclusion regex.
- **Improved Focus**: Prevents the DevTools panel from being cluttered with low-value findings.

<img width="477" height="810" alt="Screenshot_20260307_143000" src="https://github.com/user-attachments/assets/f212a5a8-fa59-446a-92e5-7c46a95a2ffe" />
